### PR TITLE
Fix args default

### DIFF
--- a/check_mariadb_slaves.py
+++ b/check_mariadb_slaves.py
@@ -122,8 +122,11 @@ class SlaveStatusCheck(NagiosPlugin):
                 conn.close()
 
 
-def main(args=sys.argv):
+def main(args=None):
     """starter method"""
+    if args is None:
+        args = sys.argv[1:]
+
     parser = argparse.ArgumentParser(description='MariaDB slave status checker')
     parser.add_argument('--hostname', default='localhost', type=str,
                         help="MariaDB hostname")

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,7 @@ import mock
 import unittest
 import check_mariadb_slaves
 import MySQLdb
+import sys
 
 
 @mock.patch('check_mariadb_slaves.sys')
@@ -162,5 +163,11 @@ class TestMain(unittest.TestCase):
         self.args += ['--username', 'test', '--password', 'test', '-w', '10',
                       '-c', '20', '--verbose']
         check_mariadb_slaves.main(self.args)
+        mock_SSC.assert_called_once_with('localhost', 'test', 'test',
+                                         'connection', 'test', True, 10, 20)
+
+        mock_SSC.reset_mock()
+        sys.argv = ["myscriptname.py"] + self.args
+        check_mariadb_slaves.main()
         mock_SSC.assert_called_once_with('localhost', 'test', 'test',
                                          'connection', 'test', True, 10, 20)


### PR DESCRIPTION
As mentioned in comment faa3c2d#commitcomment-15392749
when calling check_mariadb_slaves.main() without arguments, the list got from sys.argv
contains the script name as first element. This PR restructures the handling of
default argument list slightly, in order to fix this issue and added a test
which is intended to cover this case.
