### PR TITLE
Replication lag formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You may have different paths, but here's an example of the above:
 - -w or --warning - warning threshold; currently only required for ```replication_lag``` mode
 - -c or --critical - critical threshold; currently only required for ```replication_lag``` mode
 - --verbose - [*optional*] - for testing purposes; currently prints out the result of the slave status query when used
+- -H or --human-readable - [*optional*] - display human readable replication lag (only valid for ```replication_lag``` mode)
 
 ## Example Usage
 Here's an example of Nagios command and service definitions that implement this plugin:

--- a/check_mariadb_slaves.py
+++ b/check_mariadb_slaves.py
@@ -28,11 +28,13 @@ def main(args=None):
                         help="critical limit")
     parser.add_argument('--verbose', action='store_true', default=False,
                         help="enable verbose mode")
+    parser.add_argument('-H', '--human-readable', action='store_true',
+                        default=False, help="human readable replication lag")
 
     args = parser.parse_args(args)
     ssc = SlaveStatusCheck(args.hostname, args.username, args.password,
                            args.connection, args.mode, args.verbose,
-                           args.warning, args.critical)
+                           args.warning, args.critical, args.human_readable)
     ssc.get_slave_status()
     ssc.run_check()
 

--- a/nagios_plugin/lag_formatter.py
+++ b/nagios_plugin/lag_formatter.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+import time
+from collections import OrderedDict
+
+
+class LagFormatter(object):
+
+    PARTS_MAP = OrderedDict([
+        ('hour', 'hour'),
+        ('min', 'minute'),
+        ('sec', 'second')
+    ])
+
+    def format(self, seconds):
+        seconds = time.gmtime(int(seconds))
+        parts = []
+
+        for key in self.PARTS_MAP.keys():
+            value = getattr(seconds, 'tm_{}'.format(key), 0)
+            if value:
+                parts.append(self._get_formatted_part(key, value))
+
+        return ' '.join(parts)
+
+    def _get_formatted_part(self, key, value):
+        return '{} {}{}'.format(
+            value,
+            self.PARTS_MAP.get(key),
+            's' if value > 1 else ''
+        )

--- a/nagios_plugin/lag_formatter.py
+++ b/nagios_plugin/lag_formatter.py
@@ -3,29 +3,25 @@
 import time
 from collections import OrderedDict
 
+PARTS_MAP = OrderedDict([
+    ('hour', 'hour'),
+    ('min', 'minute'),
+    ('sec', 'second')
+])
 
-class LagFormatter(object):
 
-    PARTS_MAP = OrderedDict([
-        ('hour', 'hour'),
-        ('min', 'minute'),
-        ('sec', 'second')
-    ])
+def format_lag(seconds):
+    seconds = time.gmtime(int(seconds))
+    parts = []
 
-    def format(self, seconds):
-        seconds = time.gmtime(int(seconds))
-        parts = []
+    for key in PARTS_MAP.keys():
+        value = getattr(seconds, 'tm_{}'.format(key), 0)
+        if value:
+            formatted_part = '{} {}{}'.format(
+                value,
+                PARTS_MAP.get(key),
+                's' if value > 1 else ''
+            )
+            parts.append(formatted_part)
 
-        for key in self.PARTS_MAP.keys():
-            value = getattr(seconds, 'tm_{}'.format(key), 0)
-            if value:
-                parts.append(self._get_formatted_part(key, value))
-
-        return ' '.join(parts)
-
-    def _get_formatted_part(self, key, value):
-        return '{} {}{}'.format(
-            value,
-            self.PARTS_MAP.get(key),
-            's' if value > 1 else ''
-        )
+    return ' '.join(parts)

--- a/nagios_plugin/plugin.py
+++ b/nagios_plugin/plugin.py
@@ -17,8 +17,8 @@ class SlaveStatusCheck(NagiosPlugin):
              SLAVESQL_MODE,
              SLAVEIO_MODE)
 
-    def __init__(self, hostname, username, password, connection_name,
-                 mode, verbose=False, warning=None, critical=None):
+    def __init__(self, hostname, username, password, connection_name, mode,
+                 verbose=False, warning=None, critical=None, human_readable=False):
         super(SlaveStatusCheck, self).__init__(warning, critical)
 
         self.hostname = hostname
@@ -26,6 +26,7 @@ class SlaveStatusCheck(NagiosPlugin):
         self.password = password
         self.connection_name = connection_name
         self.verbose = verbose
+        self.human_readable = human_readable
         self.mode = mode
         self._slave_status = {}
 
@@ -46,7 +47,8 @@ class SlaveStatusCheck(NagiosPlugin):
         lag = int(lag)
         warning = int(self.warning)
         critical = int(self.critical)
-        lag_msg = "Slave is {0} behind master | replication_lag={0};{1};{2}".format(format_lag(lag), warning, critical)
+        formatted_lag = format_lag(lag) if self.human_readable else lag
+        lag_msg = "Slave is {0} behind master | replication_lag={0};{1};{2}".format(formatted_lag, warning, critical)
 
         if lag >= warning and lag < critical:
             self.warning_state(lag_msg)

--- a/nagios_plugin/plugin.py
+++ b/nagios_plugin/plugin.py
@@ -5,6 +5,7 @@ __all__ = ['SlaveStatusCheck']
 
 import MySQLdb
 from .base import NagiosPlugin
+from .lag_formatter import format_lag
 
 
 class SlaveStatusCheck(NagiosPlugin):
@@ -45,7 +46,7 @@ class SlaveStatusCheck(NagiosPlugin):
         lag = int(lag)
         warning = int(self.warning)
         critical = int(self.critical)
-        lag_msg = "Slave is {0} seconds behind master | replication_lag={0};{1};{2}".format(lag, warning, critical)
+        lag_msg = "Slave is {0} behind master | replication_lag={0};{1};{2}".format(format_lag(lag), warning, critical)
 
         if lag >= warning and lag < critical:
             self.warning_state(lag_msg)

--- a/nagios_plugin/plugin.py
+++ b/nagios_plugin/plugin.py
@@ -47,8 +47,13 @@ class SlaveStatusCheck(NagiosPlugin):
         lag = int(lag)
         warning = int(self.warning)
         critical = int(self.critical)
-        formatted_lag = format_lag(lag) if self.human_readable else lag
-        lag_msg = "Slave is {0} behind master | replication_lag={0};{1};{2}".format(formatted_lag, warning, critical)
+
+        if self.human_readable:
+            formatted_lag = format_lag(lag)
+        else:
+            formatted_lag = '{} seconds'.format(lag)
+
+        lag_msg = "Slave is {0} behind master | replication_lag={1};{2};{3}".format(formatted_lag, lag, warning, critical)
 
         if lag >= warning and lag < critical:
             self.warning_state(lag_msg)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='check-mariadb-slaves',
-    version='2.0',
+    version='2.1',
     include_package_data=True,
     packages=find_packages(),
     install_requires=[

--- a/tests/nagios_plugin/test_lag_formatter.py
+++ b/tests/nagios_plugin/test_lag_formatter.py
@@ -2,21 +2,18 @@
 
 import unittest
 
-from nagios_plugin.lag_formatter import LagFormatter
+from nagios_plugin.lag_formatter import format_lag
 
 
 class TestLagFormatter(unittest.TestCase):
 
-    def setUp(self):
-        self.lag_formatter = LagFormatter()
-
     def test_response_contains_all_parts(self):
-        self.assertEquals(self.lag_formatter.format(3661), '1 hour 1 minute 1 second')
+        self.assertEquals(format_lag(3661), '1 hour 1 minute 1 second')
 
     def test_response_ignores_empty_parts(self):
-        self.assertEquals(self.lag_formatter.format(3601), '1 hour 1 second')
-        self.assertEquals(self.lag_formatter.format(61), '1 minute 1 second')
-        self.assertEquals(self.lag_formatter.format(3600), '1 hour')
+        self.assertEquals(format_lag(3601), '1 hour 1 second')
+        self.assertEquals(format_lag(61), '1 minute 1 second')
+        self.assertEquals(format_lag(3600), '1 hour')
 
     def test_response_adds_plural_to_formatted_parts(self):
-        self.assertEquals(self.lag_formatter.format(7322), '2 hours 2 minutes 2 seconds')
+        self.assertEquals(format_lag(7322), '2 hours 2 minutes 2 seconds')

--- a/tests/nagios_plugin/test_lag_formatter.py
+++ b/tests/nagios_plugin/test_lag_formatter.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from nagios_plugin.lag_formatter import LagFormatter
+
+
+class TestLagFormatter(unittest.TestCase):
+
+    def setUp(self):
+        self.lag_formatter = LagFormatter()
+
+    def test_response_contains_all_parts(self):
+        self.assertEquals(self.lag_formatter.format(3661), '1 hour 1 minute 1 second')
+
+    def test_response_ignores_empty_parts(self):
+        self.assertEquals(self.lag_formatter.format(3601), '1 hour 1 second')
+        self.assertEquals(self.lag_formatter.format(61), '1 minute 1 second')
+        self.assertEquals(self.lag_formatter.format(3600), '1 hour')
+
+    def test_response_adds_plural_to_formatted_parts(self):
+        self.assertEquals(self.lag_formatter.format(7322), '2 hours 2 minutes 2 seconds')

--- a/tests/nagios_plugin/test_lag_formatter.py
+++ b/tests/nagios_plugin/test_lag_formatter.py
@@ -8,12 +8,12 @@ from nagios_plugin.lag_formatter import format_lag
 class TestLagFormatter(unittest.TestCase):
 
     def test_response_contains_all_parts(self):
-        self.assertEquals(format_lag(3661), '1 hour 1 minute 1 second')
+        self.assertEqual(format_lag(3661), '1 hour 1 minute 1 second')
 
     def test_response_ignores_empty_parts(self):
-        self.assertEquals(format_lag(3601), '1 hour 1 second')
-        self.assertEquals(format_lag(61), '1 minute 1 second')
-        self.assertEquals(format_lag(3600), '1 hour')
+        self.assertEqual(format_lag(3601), '1 hour 1 second')
+        self.assertEqual(format_lag(61), '1 minute 1 second')
+        self.assertEqual(format_lag(3600), '1 hour')
 
     def test_response_adds_plural_to_formatted_parts(self):
-        self.assertEquals(format_lag(7322), '2 hours 2 minutes 2 seconds')
+        self.assertEqual(format_lag(7322), '2 hours 2 minutes 2 seconds')

--- a/tests/nagios_plugin/test_plugin.py
+++ b/tests/nagios_plugin/test_plugin.py
@@ -49,19 +49,31 @@ class TestSlaveStatusCheck(unittest.TestCase):
         self.slave_status_check.critical = 100
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.slave_status_check.replication_lag()
-        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(format_lag(lag))
+        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(lag)
         self.slave_status_check.ok_state.assert_called_once_with(expected_msg)
 
         lag = 10
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.assertRaises(SystemExit, self.slave_status_check.replication_lag)
-        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(format_lag(lag))
+        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(lag)
         self.slave_status_check.warning_state.assert_called_once_with(expected_msg)
 
         lag = 100
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.assertRaises(SystemExit, self.slave_status_check.replication_lag)
-        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(format_lag(lag))
+        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(lag)
+        self.slave_status_check.critical_state.assert_called_once_with(expected_msg)
+
+    def test_human_readable_arg_formats_replication_lag(self):
+        lag = 100
+        formatted_lag = format_lag(lag)
+        self.slave_status_check.warning = 10
+        self.slave_status_check.critical = 100
+        self.slave_status_check.human_readable = True
+        self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
+        self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
+        self.assertRaises(SystemExit, self.slave_status_check.replication_lag)
+        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(formatted_lag)
         self.slave_status_check.critical_state.assert_called_once_with(expected_msg)
 
     def test_slave_sql(self):

--- a/tests/nagios_plugin/test_plugin.py
+++ b/tests/nagios_plugin/test_plugin.py
@@ -49,19 +49,19 @@ class TestSlaveStatusCheck(unittest.TestCase):
         self.slave_status_check.critical = 100
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.slave_status_check.replication_lag()
-        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(lag)
+        expected_msg = "Slave is {0} seconds behind master | replication_lag={0};10;100".format(lag)
         self.slave_status_check.ok_state.assert_called_once_with(expected_msg)
 
         lag = 10
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.assertRaises(SystemExit, self.slave_status_check.replication_lag)
-        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(lag)
+        expected_msg = "Slave is {0} seconds behind master | replication_lag={0};10;100".format(lag)
         self.slave_status_check.warning_state.assert_called_once_with(expected_msg)
 
         lag = 100
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.assertRaises(SystemExit, self.slave_status_check.replication_lag)
-        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(lag)
+        expected_msg = "Slave is {0} seconds behind master | replication_lag={0};10;100".format(lag)
         self.slave_status_check.critical_state.assert_called_once_with(expected_msg)
 
     def test_human_readable_arg_formats_replication_lag(self):
@@ -73,7 +73,7 @@ class TestSlaveStatusCheck(unittest.TestCase):
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.assertRaises(SystemExit, self.slave_status_check.replication_lag)
-        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(formatted_lag)
+        expected_msg = "Slave is {0} behind master | replication_lag={1};10;100".format(formatted_lag, lag)
         self.slave_status_check.critical_state.assert_called_once_with(expected_msg)
 
     def test_slave_sql(self):

--- a/tests/nagios_plugin/test_plugin.py
+++ b/tests/nagios_plugin/test_plugin.py
@@ -5,6 +5,7 @@ import mock
 import MySQLdb
 
 from nagios_plugin.plugin import SlaveStatusCheck
+from nagios_plugin.lag_formatter import format_lag
 
 
 class TestSlaveStatusCheck(unittest.TestCase):
@@ -48,19 +49,19 @@ class TestSlaveStatusCheck(unittest.TestCase):
         self.slave_status_check.critical = 100
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.slave_status_check.replication_lag()
-        expected_msg = "Slave is {0} seconds behind master | replication_lag={0};10;100".format(lag)
+        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(format_lag(lag))
         self.slave_status_check.ok_state.assert_called_once_with(expected_msg)
 
         lag = 10
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.assertRaises(SystemExit, self.slave_status_check.replication_lag)
-        expected_msg = "Slave is {0} seconds behind master | replication_lag={0};10;100".format(lag)
+        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(format_lag(lag))
         self.slave_status_check.warning_state.assert_called_once_with(expected_msg)
 
         lag = 100
         self.slave_status_check._slave_status["Seconds_Behind_Master"] = lag
         self.assertRaises(SystemExit, self.slave_status_check.replication_lag)
-        expected_msg = "Slave is {0} seconds behind master | replication_lag={0};10;100".format(lag)
+        expected_msg = "Slave is {0} behind master | replication_lag={0};10;100".format(format_lag(lag))
         self.slave_status_check.critical_state.assert_called_once_with(expected_msg)
 
     def test_slave_sql(self):

--- a/tests/test_check_mariadb_slaves.py
+++ b/tests/test_check_mariadb_slaves.py
@@ -26,17 +26,17 @@ class TestMain(unittest.TestCase):
         mock_SSC.MODES = ('test')
         check_mariadb_slaves.main(self.args)
         mock_SSC.assert_called_once_with('localhost', None, None, 'connection',
-                                         'test', False, None, None)
+                                         'test', False, None, None, False)
 
         mock_SSC.reset_mock()
         self.args += ['--username', 'test', '--password', 'test', '-w', '10',
                       '-c', '20', '--verbose']
         check_mariadb_slaves.main(self.args)
         mock_SSC.assert_called_once_with('localhost', 'test', 'test',
-                                         'connection', 'test', True, 10, 20)
+                                         'connection', 'test', True, 10, 20, False)
 
         mock_SSC.reset_mock()
         sys.argv = ["myscriptname.py"] + self.args
         check_mariadb_slaves.main()
         mock_SSC.assert_called_once_with('localhost', 'test', 'test',
-                                         'connection', 'test', True, 10, 20)
+                                         'connection', 'test', True, 10, 20, False)


### PR DESCRIPTION
This is merely a cosmetic thing, and also I'm lazy to convert seconds.
As you could see from the tests, it will format the replication lag seconds into a readable format, for example: `61 seconds` is `1 minute 1 second`. This is just an easy example, but when we have `274 seconds` replication it becomes a little more difficult.